### PR TITLE
Use multi-stage builds to reduce size of final docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
-FROM golang:1.9-alpine
-
+FROM golang:1.9
 WORKDIR /go/src/github.com/Fresh-Tracks/avalanche
 COPY . .
+RUN CGO_ENABLED=0 GOOS=linux go build -o=/bin/avalanche ./cmd
 
-ENV CGO_ENABLED=0
-
-RUN go build -o=/bin/avalanche ./cmd
-
+FROM scratch
+COPY --from=0 /bin/avalanche /bin/avalanche
+EXPOSE 9001
 ENTRYPOINT ["/bin/avalanche"]


### PR DESCRIPTION
Using multi-stage builds i was able to bring down the size of the final docker image from 309MB to 10.8MB:

```
krausm/avalanche                   latest              3197fe9544fa        About an hour ago   10.8MB
quay.io/freshtracks.io/avalanche   latest              a2aa6906d7d7        3 weeks ago         309MB
```

Best regards, Michael