### PR TITLE
Allow the tenant ID to be specified for remote_write

### DIFF
--- a/cmd/avalanche.go
+++ b/cmd/avalanche.go
@@ -19,6 +19,7 @@ var (
 	metricInterval = kingpin.Flag("metric-interval", "Change __name__ label values every {interval} seconds.").Default("120").Int()
 	port           = kingpin.Flag("port", "Port to serve at").Default("9001").Int()
 	remoteURL      = kingpin.Flag("remote-url", "URL to send samples via remote_write API.").URL()
+	remoteTenant   = kingpin.Flag("remote-tenant", "Tenant ID to include in remote_write send").Default("1").String()
 )
 
 func main() {
@@ -34,7 +35,7 @@ func main() {
 	}
 	if *remoteURL != nil {
 		// First cut: just send the metrics once then exit
-		err = metrics.SendRemoteWrite(**remoteURL)
+		err = metrics.SendRemoteWrite(**remoteURL, *remoteTenant)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -29,9 +29,9 @@ type Client struct {
 	timeout time.Duration
 }
 
-func SendRemoteWrite(u url.URL) error {
+func SendRemoteWrite(u url.URL, tenant string) error {
 	var rt http.RoundTripper = &http.Transport{}
-	rt = &cortexTenantRoundTripper{tenant: "0", rt: rt}
+	rt = &cortexTenantRoundTripper{tenant: tenant, rt: rt}
 	httpClient := &http.Client{Transport: rt}
 
 	c := Client{


### PR DESCRIPTION
My first cut at `remote_write` hard-coded the tenant ID to `"0"`; with this change you can send different IDs from the command-line and it now defaults to `"1"`.