### PR TITLE
Allow the tenant ID to be specified for remote_write [Rebase]

### DIFF
--- a/cmd/avalanche.go
+++ b/cmd/avalanche.go
@@ -29,6 +29,7 @@ var (
 	remoteBatchSize     = kingpin.Flag("remote-batch-size", "how many samples to send with each remote_write API request.").Default("2000").Int()
 	remoteRequestCount  = kingpin.Flag("remote-requests-count", "how many requests to send in total to the remote_write API.").Default("100").Int()
 	remoteReqsInterval  = kingpin.Flag("remote-write-interval", "delay between each remote write request.").Default("100ms").Duration()
+	remoteTenant        = kingpin.Flag("remote-tenant", "Tenant ID to include in remote_write send").Default("0").String()
 )
 
 func main() {
@@ -58,6 +59,7 @@ func main() {
 			BatchSize:       *remoteBatchSize,
 			RequestCount:    *remoteRequestCount,
 			UpdateNotify:    updateNotify,
+			Tenant:          *remoteTenant,
 		}
 
 		// Collect Pprof during the write only if not collecting within a regular interval.

--- a/metrics/write.go
+++ b/metrics/write.go
@@ -35,6 +35,7 @@ type ConfigWrite struct {
 	RequestCount int
 	UpdateNotify chan struct{}
 	PprofURLs    []*url.URL
+	Tenant       string
 }
 
 // Client for the remote write requests.
@@ -48,7 +49,7 @@ type Client struct {
 // sends metrics to a prometheus compatible remote endpoint.
 func SendRemoteWrite(config ConfigWrite) error {
 	var rt http.RoundTripper = &http.Transport{}
-	rt = &cortexTenantRoundTripper{tenant: "0", rt: rt}
+	rt = &cortexTenantRoundTripper{tenant: config.Tenant, rt: rt}
 	httpClient := &http.Client{Transport: rt}
 
 	c := Client{


### PR DESCRIPTION
Closes #7 and is just a rebase of it with the addition of setting the default tenant ID to `0` like requested in that PR. Seemed to me the original PR was too old to bug @bboreham to update it.